### PR TITLE
Add padding and height to NewPost module

### DIFF
--- a/app/new/(new)/mobile/NewPost.module.scss
+++ b/app/new/(new)/mobile/NewPost.module.scss
@@ -3,4 +3,6 @@ $block-width: 90dvw;
 .newPost {
   display: grid;
   grid-template-rows: 10% 80% 10%;
+  padding: calc(8dvh + 0.5rem) 0.5rem calc(10dvh + 0.5rem) 0.5rem;
+  height: 100dvh;
 }

--- a/app/new/(new)/mobile/NewPost.tsx
+++ b/app/new/(new)/mobile/NewPost.tsx
@@ -39,11 +39,7 @@ export default function NewPostMobile({
         data={data}
         handleFormEventFunction={handleFormEventFunction}
       ></MetaDataForm>
-      <Editor
-        setPostData={setPostData}
-        data={data}
-        token={token}
-      ></Editor>
+      <Editor setPostData={setPostData} data={data} token={token}></Editor>
       <Button
         discardFunction={discardFunction}
         postFunction={postFunction}


### PR DESCRIPTION
Problem
1. the former layout of new post page in mobile was broken in new mobile layout

Adjustment:
1. make new page block height 100dvh
2. get padding to avoid being covered by headerbar and toolbar