### PR TITLE
fix: new post page shaking bug

### DIFF
--- a/app/new/(new)/mobile/NewPost.tsx
+++ b/app/new/(new)/mobile/NewPost.tsx
@@ -39,7 +39,9 @@ export default function NewPostMobile({
         data={data}
         handleFormEventFunction={handleFormEventFunction}
       ></MetaDataForm>
-      <Editor setPostData={setPostData} data={data} token={token}></Editor>
+      <div className="h-full">
+        <Editor setPostData={setPostData} data={data} token={token}></Editor>
+      </div>
       <Button
         discardFunction={discardFunction}
         postFunction={postFunction}


### PR DESCRIPTION
New post page shaking when opening because of dynamic rendering of editr. 
Added the default block to fill the grid block.